### PR TITLE
add alert for ticket sales deadline

### DIFF
--- a/inperson.html
+++ b/inperson.html
@@ -706,6 +706,12 @@
                           />
                         </a>
                       </div>
+                      <div class="mt-3">
+                        <div class="alert alert-warning" role="alert" style="background-color: #fff3cd; border-color: #ffeaa7; color: #856404; padding: 15px; border-radius: 5px; border-left: 4px solid #f39c12;">
+                          <i class="fa fa-clock-o mr-2"></i>
+                          <strong>Limited Time:</strong> Ticket sales end on September 15th, 2025. Don't miss your chance to join us!
+                        </div>
+                      </div>
                     </div>
                     <!-- <br>
                     <br>


### PR DESCRIPTION
This pull request adds a notification to the in-person event page to inform users about the ticket sales deadline.

User communication improvements:

* Added a styled alert to `inperson.html` warning users that ticket sales end on September 15th, 2025, helping to create urgency and improve clarity for attendees.

<img width="805" height="503" alt="Screenshot 2025-09-05 at 9 43 09 am" src="https://github.com/user-attachments/assets/e09565b6-4bf5-411d-939a-dcd53bec5df3" />
